### PR TITLE
Add confluence search plugin

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -146,6 +146,7 @@ proxy:
         # For more info on how to generate this token: https://www.dynatrace.com/support/help/dynatrace-api/basics/dynatrace-api-authentication
         Authorization: 'Api-Token ${DYNATRACE_ACCESS_TOKEN}'
 
+
 # Reference documentation http://backstage.io/docs/features/techdocs/configuration
 # Note: After experimenting with basic setup, use CI/CD to generate docs
 # and an external cloud storage when deploying TechDocs for production use-case.
@@ -295,7 +296,7 @@ permission:
 
 enabled:
   kubernetes: ${K8S_ENABLED}
-  techdocs: false
+  techdocs: ${TECHDOCS_ENABLED}
   argocd: ${ARGOCD_ENABLED}
   sonarqube: ${SONARQUBE_ENABLED}
   keycloak: ${KEYCLOAK_ENABLED}

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -295,7 +295,7 @@ permission:
 
 enabled:
   kubernetes: ${K8S_ENABLED}
-  techdocs: ${TECHDOCS_ENABLED}
+  techdocs: false
   argocd: ${ARGOCD_ENABLED}
   sonarqube: ${SONARQUBE_ENABLED}
   keycloak: ${KEYCLOAK_ENABLED}
@@ -306,3 +306,20 @@ enabled:
   azureDevOps: ${AZURE_ENABLED}
   jenkins: ${JENKINS_ENABLED}
   permission: ${PERMISSION_ENABLED}
+
+# Plugin Confluence
+confluence:
+  # Confluence base URL for wiki API
+  # Typically: https://{org-name}.atlassian.net/wiki
+  wikiUrl: https://org-name.atlassian.net/wiki
+
+  # List of spaces to index
+  # See https://confluence.atlassian.com/conf59/spaces-792498593.html
+  spaces: [ENG]
+
+  # Authentication credentials towards Confluence API
+  auth:
+    username: ${CONFLUENCE_USERNAME}
+    # While Confluence supports BASIC authentication, using an API token is preferred.
+    # See: https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/
+    password: ${CONFLUENCE_PASSWORD}

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -312,7 +312,7 @@ enabled:
 confluence:
   # Confluence base URL for wiki API
   # Typically: https://{org-name}.atlassian.net/wiki
-  wikiUrl: https://org-name.atlassian.net/wiki
+  wikiUrl: ${CONFLUENCE_URL}
 
   # List of spaces to index
   # See https://confluence.atlassian.com/conf59/spaces-792498593.html

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -60,6 +60,7 @@
     "@janus-idp/backstage-plugin-quay": "1.3.0",
     "@janus-idp/backstage-plugin-tekton": "1.9.2",
     "@janus-idp/backstage-plugin-topology": "1.15.1",
+    "@k-phoen/backstage-plugin-confluence": "^0.0.15",
     "@mui/icons-material": "5.14.6",
     "@mui/lab": "5.0.0-alpha.141",
     "@mui/material": "5.14.6",

--- a/packages/app/src/components/search/SearchPage.tsx
+++ b/packages/app/src/components/search/SearchPage.tsx
@@ -27,6 +27,8 @@ import {
 } from '@backstage/plugin-search-react';
 import { makeStyles } from 'tss-react/mui';
 
+import { ConfluenceResultListItem } from '@k-phoen/backstage-plugin-confluence';
+
 const useStyles = makeStyles()(theme => ({
   searchBar: {
     borderRadius: '50px',
@@ -83,6 +85,11 @@ export const SearchPage = () => {
                   name: 'Documentation',
                   icon: <DocsIcon />,
                 },
+                {
+                  value: 'confluence',
+                  name: 'Confluence',
+                  icon: <DocsIcon />,
+                },
               ]}
             />
             <Paper className={classes.filters}>
@@ -126,6 +133,7 @@ export const SearchPage = () => {
             <SearchResult>
               <CatalogSearchResultListItem icon={<CatalogIcon />} />
               <TechDocsSearchResultListItem icon={<DocsIcon />} />
+              <ConfluenceResultListItem />
             </SearchResult>
           </Grid>
         </Grid>

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -47,6 +47,7 @@
     "@janus-idp/backstage-plugin-3scale-backend": "^1.1.1",
     "@janus-idp/backstage-plugin-keycloak-backend": "1.5.3",
     "@janus-idp/backstage-plugin-ocm-backend": "3.1.1",
+    "@k-phoen/backstage-plugin-confluence-backend": "^0.0.14",
     "@microcks/microcks-backstage-provider": "^0.0.3",
     "@roadiehq/backstage-plugin-argo-cd-backend": "2.11.1",
     "@roadiehq/scaffolder-backend-argocd": "1.1.13",

--- a/packages/backend/src/plugins/search.ts
+++ b/packages/backend/src/plugins/search.ts
@@ -8,17 +8,35 @@ import { PluginEnvironment } from '../types';
 import { DefaultCatalogCollatorFactory } from '@backstage/plugin-catalog-backend';
 import { DefaultTechDocsCollatorFactory } from '@backstage/plugin-techdocs-backend';
 import { Router } from 'express';
+import { ConfluenceCollatorFactory } from '@k-phoen/backstage-plugin-confluence-backend';
 
-export default async function createPlugin(
-  env: PluginEnvironment,
-): Promise<Router> {
+export default async function createPlugin({
+  logger,
+  permissions,
+  discovery,
+  config,
+  tokenManager,
+}: PluginEnvironment) {
   // Initialize a connection to a search engine.
-  const searchEngine = new LunrSearchEngine({
-    logger: env.logger,
+  const searchEngine = await ElasticSearchSearchEngine.fromConfig({
+    logger,
+    config,
   });
-  const indexBuilder = new IndexBuilder({
-    logger: env.logger,
-    searchEngine,
+  const indexBuilder = new IndexBuilder({ logger, searchEngine });
+
+  // Confluence indexing
+  const halfHourSchedule = env.scheduler.createScheduledTaskRunner({
+    frequency: Duration.fromObject({ minutes: 30 }),
+    timeout: Duration.fromObject({ minutes: 15 }),
+    // A 3 second delay gives the backend server a chance to initialize before
+    // any collators are executed, which may attempt requests against the API.
+    initialDelay: Duration.fromObject({ seconds: 3 }),
+  });
+  indexBuilder.addCollator({
+    schedule: halfHourSchedule,
+    factory: ConfluenceCollatorFactory.fromConfig(env.config, {
+      logger: env.logger,
+    }),
   });
 
   const schedule = env.scheduler.createScheduledTaskRunner({
@@ -52,15 +70,18 @@ export default async function createPlugin(
   // The scheduler controls when documents are gathered from collators and sent
   // to the search engine for indexing.
   const { scheduler } = await indexBuilder.build();
-  scheduler.start();
+
+  // A 3 second delay gives the backend server a chance to initialize before
+  // any collators are executed, which may attempt requests against the API.
+  setTimeout(() => scheduler.start(), 3000);
 
   useHotCleanup(module, () => scheduler.stop());
 
   return await createRouter({
     engine: indexBuilder.getSearchEngine(),
     types: indexBuilder.getDocumentTypes(),
-    permissions: env.permissions,
-    config: env.config,
-    logger: env.logger,
+    permissions,
+    config,
+    logger,
   });
 }


### PR DESCRIPTION
## Description

Add confluence plugin to the backstage

## PR acceptance criteria

 - The Confluence front end plugin above is added to the source code given the steps outlined
- The Confluence back end plugin above is added to the source code given the steps outlined
 - A local run of the application should have the both plugins running 
- We should disable the TechDocs plugin by default by defaulting the `enabled.techdocs` app-config.yaml property to false

Please make sure that the following steps are complete:

- GitHub Actions are completed and successful
- Unit Tests are updated and passing
- E2E Tests are updated and passing
- Documentation is updated if necessary
- Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
